### PR TITLE
Fix "for_all" checker and add negative test

### DIFF
--- a/lib/amrita.ex
+++ b/lib/amrita.ex
@@ -514,7 +514,7 @@ defmodule Amrita do
         [2, 3, 5, 7] |> for_all odd(&1)  ; false
     """
     def for_all(collection, fun) do
-      Enum.all?(collection, fun)
+      Enum.each(collection, fun)
     end
 
     @doc """

--- a/test/integration/amrita_test.exs
+++ b/test/integration/amrita_test.exs
@@ -4,6 +4,21 @@ Code.require_file "../../test_helper.exs", __FILE__
 defmodule AmritaFacts do
   use Amrita.Sweet
 
+  defexception TestDidNotFailError, name: nil do
+    def message(exception) do
+      "Expected #{exception.name} to fail"
+    end
+  end
+
+  def fails(which, test) do
+    try do
+      test.()
+      raise TestDidNotFailError, name: which
+    rescue
+      Amrita.FactError ->
+    end
+  end
+
   describe "something" do
     it "does addition" do
       1 + 1 |> equals 2
@@ -117,6 +132,10 @@ defmodule AmritaFacts do
       [2, 4, 6, 8] |> for_all even(&1)
 
       [2, 4, 6, 8] |> Enum.all? even(&1)
+
+      fails("for_all", fn ->
+        [2, 4, 7, 8] |> for_all even(&1)
+      end)
     end
 
     fact "for_some" do


### PR DESCRIPTION
Enum.all? was short circuiting and causing the checker to pass when it
shouldn't have. Changing it to Enum.each fixed the problem.

You may want to change the mechanism for negative tests, I just
needed a way to demonstrate the problem, probably something similar
to what I have would work well, but I'm not sure about the best place to put it.
