### PR TITLE
Make sure @name_stack is defined

### DIFF
--- a/lib/amrita.ex
+++ b/lib/amrita.ex
@@ -35,7 +35,7 @@ defmodule Amrita do
         import Kernel, except: [|>: 2]
         import Amrita.Elixir.Pipeline
 
-        import Amrita.Facts
+        use Amrita.Facts
         import Amrita.Describes
 
         import Amrita.Checkers.Simple
@@ -70,6 +70,14 @@ defmodule Amrita do
     Express facts about your code.
     """
 
+    @doc false
+    defmacro __using__(_) do
+      quote do
+        @name_stack []
+        import Amrita.Facts
+      end
+    end
+
     @doc """
     A fact is the container of your test logic.
 
@@ -80,7 +88,7 @@ defmodule Amrita do
     """
     defmacro fact(description, _ // quote(do: _), contents) do
       quote do
-        test Enum.join((@name_stack || []), "") <> unquote(description) do
+        test Enum.join(@name_stack, "") <> unquote(description) do
           unquote(contents)
         end
       end
@@ -96,7 +104,7 @@ defmodule Amrita do
     """
     defmacro fact(description) do
       quote do
-        Amrita.Message.pending "Future fact: " <> Enum.join((@name_stack || []), "") <> unquote(description)
+        Amrita.Message.pending "Future fact: " <> Enum.join(@name_stack, "") <> unquote(description)
       end
     end
 
@@ -111,7 +119,7 @@ defmodule Amrita do
     """
     defmacro future_fact(description, _ // quote(do: _), _) do
       quote do
-        Amrita.Message.pending "Future fact: " <> Enum.join((@name_stack || []), "") <>  unquote(description)
+        Amrita.Message.pending "Future fact: " <> Enum.join(@name_stack, "") <>  unquote(description)
       end
     end
 
@@ -128,7 +136,7 @@ defmodule Amrita do
     """
     defmacro facts(description, _ // quote(do: _), contents) do
       quote do
-        @name_stack List.concat((@name_stack || []), [unquote(description) <> ": "])
+        @name_stack List.concat(@name_stack, [unquote(description) <> ": "])
         unquote(contents)
         if Enum.count(@name_stack) > 0 do
           @name_stack Enum.take(@name_stack, Enum.count(@name_stack) - 1)


### PR DESCRIPTION
When @name_stack is not defined, it warns by [this commit](https://github.com/elixir-lang/elixir/commit/9904bdce9d5f77de2f53a0033cb9ff930f4a3432).

before

```
/Users/yuki_ito/work/elixir/amrita% mix test
Compiled lib/amrita/elixir/string.ex
Compiled lib/amrita/elixir/pipeline.ex
Compiled lib/amrita/elixir/set.ex
Compiled lib/amrita/fact_error.ex
/Users/yuki_ito/work/elixir/amrita/lib/amrita/mocks/history.ex:6: variable a is unused
Compiled lib/amrita/mocks/history.ex
Compiled lib/amrita/mocks.ex
Compiled lib/amrita/formatter/progress.ex
Compiled lib/amrita.ex
Generated amrita.app
/Users/yuki_ito/work/elixir/amrita/test/unit/amrita/fact_error_test.exs:6: (module) undefined module attribute @name_stack, please remove access to @name_stack or explicitly set it to nil before access
/Users/yuki_ito/work/elixir/amrita/test/unit/amrita/mocks/history_test.exs:8: (module) undefined module attribute @name_stack, please remove access to @name_stack or explicitly set it to nil before access
/Users/yuki_ito/work/elixir/amrita/test/integration/mocks_test.exs:19: (module) undefined module attribute @name_stack, please remove access to @name_stack or explicitly set it to nil before access
/Users/yuki_ito/work/elixir/amrita/test/integration/mocks_test.exs:24: (module) undefined module attribute @name_stack, please remove access to @name_stack or explicitly set it to nil before access
/Users/yuki_ito/work/elixir/amrita/test/integration/mocks_test.exs:30: (module) undefined module attribute @name_stack, please remove access to @name_stack or explicitly set it to nil before access
/Users/yuki_ito/work/elixir/amrita/test/integration/mocks_test.exs:36: (module) undefined module attribute @name_stack, please remove access to @name_stack or explicitly set it to nil before access
/Users/yuki_ito/work/elixir/amrita/test/integration/mocks_test.exs:41: (module) undefined module attribute @name_stack, please remove access to @name_stack or explicitly set it to nil before access
/Users/yuki_ito/work/elixir/amrita/test/integration/mocks_test.exs:55: (module) undefined module attribute @name_stack, please remove access to @name_stack or explicitly set it to nil before access
/Users/yuki_ito/work/elixir/amrita/test/integration/mocks_test.exs:69: (module) undefined module attribute @name_stack, please remove access to @name_stack or explicitly set it to nil before access
/Users/yuki_ito/work/elixir/amrita/test/integration/mocks_test.exs:75: (module) undefined module attribute @name_stack, please remove access to @name_stack or explicitly set it to nil before access
Future fact: mock with a elixir complex argument
/Users/yuki_ito/work/elixir/amrita/test/integration/mocks_test.exs:89: (module) undefined module attribute @name_stack, please remove access to @name_stack or explicitly set it to nil before access
/Users/yuki_ito/work/elixir/amrita/test/integration/mocks_test.exs:95: (module) undefined module attribute @name_stack, please remove access to @name_stack or explicitly set it to nil before access
/Users/yuki_ito/work/elixir/amrita/test/integration/mocks_test.exs:102: (module) undefined module attribute @name_stack, please remove access to @name_stack or explicitly set it to nil before access
/Users/yuki_ito/work/elixir/amrita/test/integration/mocks_test.exs:108: (module) undefined module attribute @name_stack, please remove access to @name_stack or explicitly set it to nil before access
/Users/yuki_ito/work/elixir/amrita/test/integration/mocks_test.exs:114: (module) undefined module attribute @name_stack, please remove access to @name_stack or explicitly set it to nil before access
/Users/yuki_ito/work/elixir/amrita/test/integration/mocks_test.exs:120: (module) undefined module attribute @name_stack, please remove access to @name_stack or explicitly set it to nil before access
/Users/yuki_ito/work/elixir/amrita/test/integration/mocks_test.exs:126: (module) undefined module attribute @name_stack, please remove access to @name_stack or explicitly set it to nil before access
/Users/yuki_ito/work/elixir/amrita/test/integration/mocks_test.exs:132: (module) undefined module attribute @name_stack, please remove access to @name_stack or explicitly set it to nil before access
Future fact: regex are matched against argument parameters
/Users/yuki_ito/work/elixir/amrita/test/integration/amrita_test.exs:8: (module) undefined module attribute @name_stack, please remove access to @name_stack or explicitly set it to nil before access
Future fact: about collection matchers: without a body is considered pending
..............................................

Finished in 0.8 seconds (0.6s on load, 0.2s on tests)
46 facts, 0 failures
```

after

```
/Users/yuki_ito/work/elixir/amrita% mix test
Compiled lib/amrita/elixir/string.ex
Compiled lib/amrita/elixir/pipeline.ex
Compiled lib/amrita/elixir/set.ex
Compiled lib/amrita/fact_error.ex
/Users/yuki_ito/work/elixir/amrita/lib/amrita/mocks/history.ex:6: variable a is unused
Compiled lib/amrita/mocks/history.ex
Compiled lib/amrita/mocks.ex
Compiled lib/amrita/formatter/progress.ex
Compiled lib/amrita.ex
Generated amrita.app
Future fact: mock with a elixir complex argument
Future fact: regex are matched against argument parameters
Future fact: about collection matchers: without a body is considered pending
..............................................

Finished in 0.7 seconds (0.5s on load, 0.2s on tests)
46 facts, 0 failures
```
