### PR TITLE
Added parameter matching for received messages

### DIFF
--- a/test/integration/t_amrita.exs
+++ b/test/integration/t_amrita.exs
@@ -224,21 +224,21 @@ defmodule Integration.AmritaFacts do
 
     fact "received" do
       self <- :hello
-      received |> msg(:hello)
+      received |> :hello
 
       fail "wrong match" do
         self <- :sod
-        received |> msg(:hello)
+        received |> :hello
       end
 
       fail "never received message" do
-        received |> msg(:hello)
+        received |> :hello
       end
     end
 
-    future_fact "received with paramters" do
+    fact "received with paramters" do
       self <- { :hello, "sir" }
-      received |> { :hello, _ }
+      received |> matches { :hello, _ }
     end
   end
 


### PR DESCRIPTION
ISSUE #47 this allows the received function to work with a simple pipe for
equals as well as match  parameters via the matches macro

Currently the check in the equals macro is limited to received itself, this
should probably just be a is_function, but I didn't get it to work inside the
macro :(
