### PR TITLE
support matches without explicit matches call

### DIFF
--- a/lib/amrita/checkers/simple.ex
+++ b/lib/amrita/checkers/simple.ex
@@ -158,8 +158,14 @@ defmodule Amrita.Checkers.Simple do
     end
 
     if(use_match) do
-      quote do
-        unquote(actual) |> matches unquote(expected)
+      if(need_extract) do
+        quote do
+          unquote(actual).() |> matches unquote(expected)
+        end
+      else
+        quote do
+          unquote(actual) |> matches unquote(expected)
+        end
       end
     else
       if(need_extract) do

--- a/lib/amrita/elixir/pipeline.ex
+++ b/lib/amrita/elixir/pipeline.ex
@@ -15,8 +15,8 @@ defmodule Amrita.Elixir.Pipeline do
     { call, line, [left] }
   end
 
-  # Comparing tuples
-  defp pipeline_op({ :{}, _, _ }=left, { :{}, _, _ }=right) do
+  # Comparing to tuples
+  defp pipeline_op(left, { :{}, _, _ }=right) do
     quote do
       Amrita.Checkers.Simple.matches(unquote(left), unquote(right))
     end

--- a/test/integration/t_amrita.exs
+++ b/test/integration/t_amrita.exs
@@ -236,9 +236,14 @@ defmodule Integration.AmritaFacts do
       end
     end
 
-    fact "received with paramters" do
+    fact "received tuples" do
+      self <- { :hello, 1, 2 }
+      received |> { :hello, _, 2 }
+    end
+
+    future_fact "received 2 element tuples" do
       self <- { :hello, "sir" }
-      received |> matches { :hello, _ }
+      received |> { :hello, _ }
     end
   end
 


### PR DESCRIPTION
received |> { :hello, 1, _ } works
