### PR TITLE
tuple matcher working for 2 and 3 element tuples

### DIFF
--- a/lib/amrita/checkers/simple.ex
+++ b/lib/amrita/checkers/simple.ex
@@ -148,6 +148,7 @@ defmodule Amrita.Checkers.Simple do
   defmacro equals(actual, expected) do
     use_match = case expected do
       { :{}, _, _ }     -> true
+      { _, _ }          -> true
       e when is_list(e) -> true
                       _ -> false
     end

--- a/lib/amrita/elixir/pipeline.ex
+++ b/lib/amrita/elixir/pipeline.ex
@@ -18,7 +18,13 @@ defmodule Amrita.Elixir.Pipeline do
   # Comparing to tuples
   defp pipeline_op(left, { :{}, _, _ }=right) do
     quote do
-      Amrita.Checkers.Simple.matches(unquote(left), unquote(right))
+      unquote(left) |> equals unquote(right)
+    end
+  end
+
+  defp pipeline_op(left, { _, _ }=right) do
+    quote do
+      unquote(left) |> equals unquote(right)
     end
   end
 

--- a/test/integration/t_amrita.exs
+++ b/test/integration/t_amrita.exs
@@ -122,6 +122,8 @@ defmodule Integration.AmritaFacts do
 
       fact "tuples use matches when used with equals" do
         { 1, 2, 3 } |> equals { 1, _, 3 }
+        # { 1, 2 } is actually a different code path than { 1, 2, 3 }
+        { 1, 2 } |> equals { 1, _ }
         { 1, 2, { 1, 2 } } |> equals { 1, _,  { 1, _ } }
 
         fail do
@@ -129,6 +131,11 @@ defmodule Integration.AmritaFacts do
 
           { 1, 2, { 1, 2 } } |> equals { 1, _,  { 1, 4 } }
         end
+      end
+
+      fact "tuples use equals matcher implicitly" do
+        { 1, 2, 3 } |> { 1, _, 3 }
+        { 1, 2 } |> { 1, _ }
       end
 
       fact "lists use matches when used with equals" do
@@ -239,11 +246,6 @@ defmodule Integration.AmritaFacts do
     fact "received tuples" do
       self <- { :hello, 1, 2 }
       received |> { :hello, _, 2 }
-    end
-
-    future_fact "received 2 element tuples" do
-      self <- { :hello, "sir" }
-      received |> { :hello, _ }
     end
   end
 


### PR DESCRIPTION
FIXES #72

makes { 1, 2 } |> { 1, _ } since this parses to a different code than a 3
element tuple this has to be handled seperatly
