### PR TITLE
apply latest capture format

### DIFF
--- a/lib/amrita/formatter/documentation.ex
+++ b/lib/amrita/formatter/documentation.ex
@@ -71,16 +71,16 @@ defmodule Amrita.Formatter.Documentation do
       print_indent(name_parts)
       IO.write success(String.lstrip "#{Enum.at(name_parts, Enum.count(name_parts)-1)}\n")
 
-      { :noreply, config.update_tests_counter(&1 + 1) }
+      { :noreply, config.update_tests_counter(&(&1 + 1)) }
     else
       IO.puts success("\r  #{format_test_name test}")
-      { :noreply, config.update_tests_counter(&1 + 1) }
+      { :noreply, config.update_tests_counter(&(&1 + 1)) }
     end
   end
 
   def handle_cast({ :test_finished, ExUnit.Test[failure: { :invalid, _ }] = test }, config) do
     IO.puts invalid("\r  #{format_test_name test}")
-    { :noreply, config.update_tests_counter(&1 + 1).update_invalid_counter(&1 + 1) }
+    { :noreply, config.update_tests_counter(&(&1 + 1)).update_invalid_counter(&(&1 + 1)) }
   end
 
   def handle_cast({ :test_finished, test }, config) do
@@ -98,15 +98,15 @@ defmodule Amrita.Formatter.Documentation do
       else
         IO.puts  pending("  #{format_test_name test}")
       end
-      { :noreply, config.update_pending_counter(&1 + 1).
-        update_pending_failures([test|&1]) }
+      { :noreply, config.update_pending_counter(&(&1 + 1)).
+        update_pending_failures(&([test|&1])) }
     else
       if(name_parts) do
         IO.write failure(String.lstrip "#{Enum.at(name_parts, Enum.count(name_parts)-1)}\n")
       else
         IO.puts  failure("  #{format_test_name test}")
       end
-      { :noreply, config.update_tests_counter(&1 + 1).update_test_failures([test|&1]) }
+      { :noreply, config.update_tests_counter(&(&1 + 1)).update_test_failures(&([test|&1])) }
     end
   end
 
@@ -117,7 +117,7 @@ defmodule Amrita.Formatter.Documentation do
 
   def handle_cast({ :case_finished, test_case }, config) do
     if test_case.failure do
-      { :noreply, config.update_case_failures([test_case|&1]) }
+      { :noreply, config.update_case_failures(&([test_case|&1])) }
     else
       { :noreply, config }
     end
@@ -133,7 +133,7 @@ defmodule Amrita.Formatter.Documentation do
 
   defp print_suite(counter, 0, num_pending, [], [], pending_failures, run_us, load_us) do
     IO.write "\n\nPending:\n\n"
-    Enum.reduce Enum.reverse(pending_failures), 0, print_test_pending(&1, &2)
+    Enum.reduce Enum.reverse(pending_failures), 0, &print_test_pending(&1, &2)
 
     IO.puts format_time(run_us, load_us)
     IO.write success("#{counter} facts, ")
@@ -149,12 +149,12 @@ defmodule Amrita.Formatter.Documentation do
 
     if num_pending > 0 do
       IO.write "Pending:\n\n"
-      Enum.reduce Enum.reverse(pending_failures), 0, print_test_pending(&1, &2)
+      Enum.reduce Enum.reverse(pending_failures), 0, &print_test_pending(&1, &2)
     end
 
     IO.write "Failures:\n\n"
-    num_fails = Enum.reduce Enum.reverse(test_failures), 0, print_test_failure(&1, &2)
-    Enum.reduce Enum.reverse(case_failures), num_fails, print_test_case_failure(&1, &2)
+    num_fails = Enum.reduce Enum.reverse(test_failures), 0, &print_test_failure(&1, &2)
+    Enum.reduce Enum.reverse(case_failures), num_fails, &print_test_case_failure(&1, &2)
 
     IO.puts format_time(run_us, load_us)
     message = "#{counter} facts"

--- a/lib/amrita/formatter/progress.ex
+++ b/lib/amrita/formatter/progress.ex
@@ -71,7 +71,7 @@ defmodule Amrita.Formatter.Progress do
     else
       IO.write success(".")
     end
-    { :noreply, config.update_tests_counter(&1 + 1) }
+    { :noreply, config.update_tests_counter(&(&1 + 1)) }
   end
 
   def handle_cast({ :test_finished, ExUnit.Test[failure: { :invalid, _ }] = test }, config) do
@@ -80,8 +80,8 @@ defmodule Amrita.Formatter.Progress do
     else
       IO.write invalid("?")
     end
-    { :noreply, config.update_tests_counter(&1 + 1).
-        update_invalid_counter(&1 + 1) }
+    { :noreply, config.update_tests_counter(&(&1 + 1)).
+        update_invalid_counter(&(&1 + 1)) }
   end
 
   def handle_cast({ :test_finished, test }, config) do
@@ -94,16 +94,16 @@ defmodule Amrita.Formatter.Progress do
       else
         IO.write invalid("P")
       end
-      { :noreply, config.update_pending_counter(&1 + 1).
-        update_pending_failures([test|&1]) }
+      { :noreply, config.update_pending_counter(&(&1 + 1)).
+        update_pending_failures(&([test|&1])) }
     else
       if config.trace do
         IO.puts failure("\r  * #{trace_test_name test}")
       else
         IO.write failure("F")
       end
-    { :noreply, config.update_tests_counter(&1 + 1).
-        update_test_failures([test|&1]) }
+    { :noreply, config.update_tests_counter(&(&1 + 1)).
+        update_test_failures(&([test|&1])) }
     end
   end
 
@@ -114,7 +114,7 @@ defmodule Amrita.Formatter.Progress do
 
   def handle_cast({ :case_finished, test_case }, config) do
     if test_case.failure do
-      { :noreply, config.update_case_failures([test_case|&1]) }
+      { :noreply, config.update_case_failures(&([test_case|&1])) }
     else
       { :noreply, config }
     end
@@ -133,7 +133,7 @@ defmodule Amrita.Formatter.Progress do
 
   defp print_suite(counter, 0, num_pending, [], [], pending_failures, run_us, load_us) do
     IO.write "\n\nPending:\n\n"
-    Enum.reduce Enum.reverse(pending_failures), 0, print_test_pending(&1, &2)
+    Enum.reduce Enum.reverse(pending_failures), 0, &print_test_pending(&1, &2)
 
     IO.puts format_time(run_us, load_us)
     IO.write success("#{counter} facts, ")
@@ -149,12 +149,12 @@ defmodule Amrita.Formatter.Progress do
 
     if num_pending > 0 do
       IO.write "Pending:\n\n"
-      Enum.reduce Enum.reverse(pending_failures), 0, print_test_pending(&1, &2)
+      Enum.reduce Enum.reverse(pending_failures), 0, &print_test_pending(&1, &2)
     end
 
     IO.write "Failures:\n\n"
-    num_fails = Enum.reduce Enum.reverse(test_failures), 0, print_test_failure(&1, &2)
-    Enum.reduce Enum.reverse(case_failures), num_fails, print_test_case_failure(&1, &2)
+    num_fails = Enum.reduce Enum.reverse(test_failures), 0, &print_test_failure(&1, &2)
+    Enum.reduce Enum.reverse(case_failures), num_fails, &print_test_case_failure(&1, &2)
 
     IO.puts format_time(run_us, load_us)
     message = "#{counter} facts"

--- a/lib/amrita/mocks.ex
+++ b/lib/amrita/mocks.ex
@@ -232,7 +232,7 @@ defmodule Amrita.Mocks do
     end
 
     def prerequisites(forms) do
-      prerequisites = Enum.map(forms, extract(&1))
+      prerequisites = Enum.map(forms, &extract(&1))
       Provided.Prerequisites.new(prerequisites)
     end
 

--- a/lib/mix/tasks/amrita.ex
+++ b/lib/mix/tasks/amrita.ex
@@ -35,7 +35,7 @@ defmodule Mix.Tasks.Amrita do
     Amrita.Engine.Start.configure(Dict.take(opts, [:trace, :max_cases, :color, :selectors]))
 
     test_paths = project[:test_paths] || ["test"]
-    Enum.each(test_paths, require_test_helper(&1))
+    Enum.each(test_paths, &require_test_helper(&1))
 
     test_paths   = if files == [], do: test_paths, else: files
     test_pattern = project[:test_pattern] || "*.exs"

--- a/test/integration/t_amrita.exs
+++ b/test/integration/t_amrita.exs
@@ -202,20 +202,20 @@ defmodule Integration.AmritaFacts do
     end
 
     fact "for_all" do
-      [2, 4, 6, 8] |> for_all even(&1)
+      [2, 4, 6, 8] |> for_all(fn(x) -> even(x) end)
 
-      [2, 4, 6, 8] |> Enum.all? even(&1)
+      [2, 4, 6, 8] |> Enum.all?(fn(x) -> even(x) end)
 
       fail do
-        [2, 4, 7, 8] |> for_all even(&1)
+        [2, 4, 7, 8] |> for_all(fn(x) -> even(x) end)
       end
     end
 
     fact "for_some" do
-      [2, 4, 7, 8] |> for_some odd(&1)
+      [2, 4, 7, 8] |> for_some(fn(x) -> odd(x) end)
 
       fail do
-        [1, 3, 5, 7] |> for_some even(&1)
+        [1, 3, 5, 7] |> for_some(fn(x) -> even(x) end)
       end
     end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -28,7 +28,7 @@ defmodule Support do
   end
 
   defmodule Wrap do
-    def assertions([ do: forms ]) when is_list(forms), do: [do: Enum.map(forms, assertions(&1))]
+    def assertions([ do: forms ]) when is_list(forms), do: [do: Enum.map(forms, &assertions(&1))]
 
     def assertions([ do: { :provided, [line: line], [a, mocks] } ]) do
       inject_exception_test([ do: { :provided, [line: line], [a, assertions(mocks)]}], line)
@@ -37,7 +37,7 @@ defmodule Support do
     def assertions([ do: thing ]), do: [do: assertions(thing)]
 
     def assertions({ :__block__, m, forms }) do
-      { :__block__, m, Enum.map(forms, assertions(&1)) }
+      { :__block__, m, Enum.map(forms, &assertions(&1)) }
     end
 
     def assertions({ :|>, [line: line], _args } = test) do

--- a/test/unit/amrita/elixir/t_pipeline.exs
+++ b/test/unit/amrita/elixir/t_pipeline.exs
@@ -116,10 +116,10 @@ defmodule PipelineFacts do
     end
 
     fact "nested" do
-      [1, [2], 3] |> List.flatten |> Enum.map(&1 * 2) |> [2, 4, 6]
+      [1, [2], 3] |> List.flatten |> Enum.map(fn(x) -> (x * 2) end) |> [2, 4, 6]
 
       fail do
-        [1, [2], 3] |> List.flatten |> Enum.map(&1 * 2) |> [2, 4, 9]
+        [1, [2], 3] |> List.flatten |> Enum.map(fn(x) -> (x * 2) end) |> [2, 4, 9]
       end
     end
 
@@ -132,17 +132,17 @@ defmodule PipelineFacts do
     end
 
     fact "map" do
-      Enum.map([1, 2, 3], &1 |> twice |> twice) |> [4, 8, 12]
+      Enum.map([1, 2, 3], &(&1 |> twice |> twice)) |> [4, 8, 12]
 
       fail do
-        Enum.map([1, 2, 3], &1 |> twice |> twice) |> [4, 8, 19]
+        Enum.map([1, 2, 3], &(&1 |> twice |> twice)) |> [4, 8, 19]
       end
     end
 
     defp twice(a), do: a * 2
 
     defp local(list) do
-      Enum.map(list, &1 * 2)
+      Enum.map(list, &(&1 * 2))
     end
   end
 


### PR DESCRIPTION
Hi. I was trying to avoid the warning/error on new capture syntax at elixir 0.10.3 and master. 
I couldn't pass the "Unsupported expression in pipeline" error, but making the test pass with & -> fn(x) temporary changes (is there any easy fix for pipeline part?). 

*\* (ArgumentError) Unsupported expression in pipeline |> operator: Enum.map(&&1 \* 2)
    lib/amrita/elixir/pipeline.ex:86: Amrita.Elixir.Pipeline.pipeline_error/1
    lib/amrita/elixir/pipeline.ex:54: Amrita.Elixir.Pipeline.pipeline_op/2
    lib/amrita/elixir/pipeline.ex:11: Amrita.Elixir.Pipeline.pipeline_op/2
    test/unit/amrita/elixir/t_pipeline.exs:119: Amrita.Elixir.Pipeline.|>/2
