### PR TITLE
Show test time with [mix amrita --trace] as similar way as ExUnit.

### DIFF
--- a/test/integration/t_mix.exs
+++ b/test/integration/t_mix.exs
@@ -18,9 +18,7 @@ defmodule Integration.Mix do
     { :ok, [] }
   end
 
-  facts "about `mix amrita`" do
-    fact "supports running tests at a specific line number" do
-      File.write!"tmp/test/t_pants.exs", "
+  @pants_template "
 defmodule PantsFacts do
   use Amrita.Sweet
 
@@ -33,11 +31,24 @@ defmodule PantsFacts do
   end
 end"
 
+  facts "about `mix amrita`" do
+    fact "supports running tests at a specific line number" do
+      File.write!"tmp/test/t_pants.exs", @pants_template
+
       out = run_mix "amrita tmp/test/t_pants.exs:9"
 
-      out |> contains "passing example"
+      out |> contains "passing example\n"
       out |> contains "1 facts, 0 failures"
     end
-  end
 
+    fact "appends runtime when trace option is specified" do
+      File.write!"tmp/test/t_pants_trace.exs", @pants_template
+
+      out = run_mix "amrita tmp/test/t_pants_trace.exs --trace"
+
+      out |> contains %r/passing example \(.+?ms\)/
+      out |> contains %r/failing example \(.+?ms\)/
+      out |> contains "2 facts, 1 failures"
+    end
+  end
 end


### PR DESCRIPTION
Hi. I'm interested in the issue #49 (Progress formatter captures and prints the slowest 10 tests), and I was playing around it.  As for the first step, how do you think about having [mix amrita --trace] as similar way as [mix test --trace]?
It's updated for success and failure tasks.

``` Shell
% mix amrita --trace
test/integration/t_scoping.exs:5: unused import Support
test/integration/t_scoping.exs:12: this clause cannot match because a previous clause at line 7 always matches

Elixir.Integration.AsyncFacts
  testing async (0.00ms)

Elixir.CheckerFacts
  converting predicates into strings 
    arity 1 renders just predicate (0.00ms)
    atom argument is rendered (0.01ms)
    nil argument is rendered (0.00ms)
    string argument is rendered (3.2ms)
  converts negated predicates into strings 
....
```
