### PR TITLE
Removing deprecated syntax for default arguments.

### DIFF
--- a/lib/amrita.ex
+++ b/lib/amrita.ex
@@ -14,7 +14,7 @@ defmodule Amrita do
       Amrita.start(formatter: Amrita.Formatter.Documentation)
 
   """
-  def start(opts // []) do
+  def start(opts \\ []) do
     formatter = Keyword.get(opts, :formatter, Amrita.Formatter.Progress)
     Amrita.Engine.Start.now formatter: formatter
   end
@@ -22,7 +22,7 @@ defmodule Amrita do
   @doc """
   Polite version of start.
   """
-  def please_start(opts // []) do
+  def please_start(opts \\ []) do
     start(opts)
   end
 
@@ -37,7 +37,7 @@ defmodule Amrita do
     """
 
     @doc false
-    defmacro __using__(opts // []) do
+    defmacro __using__(opts \\ []) do
       async = Keyword.get(opts, :async, false)
       quote do
         if !Enum.any?(__ENV__.requires, fn(x) -> x == ExUnit.Case end) do
@@ -110,7 +110,7 @@ defmodule Amrita do
           meta[:pong] |> "pong"
         end
     """
-    defmacro fact(description, provided // [], var // quote(do: _), contents) do
+    defmacro fact(description, provided \\ [], var \\ quote(do: _), contents) do
       var = case provided do
         [provided: _] -> var
         []            -> var
@@ -165,7 +165,7 @@ defmodule Amrita do
           ..
         end
     """
-    defmacro future_fact(description, _ // quote(do: _), _) do
+    defmacro future_fact(description, _ \\ quote(do: _), _) do
       quote do
         deffact Enum.join(@name_stack, "") <> unquote(fact_name(description)) do
           Amrita.Message.pending unquote(description)
@@ -184,7 +184,7 @@ defmodule Amrita do
           end
         end
     """
-    defmacro facts(description, _ // quote(do: _), contents) do
+    defmacro facts(description, _ \\ quote(do: _), contents) do
       quote do
         @name_stack Enum.concat(@name_stack, [unquote(fact_name(description)) <> " - "])
         unquote(contents)
@@ -195,7 +195,7 @@ defmodule Amrita do
     end
 
     @doc false
-    defmacro deffact(message, var // quote(do: _), contents) do
+    defmacro deffact(message, var \\ quote(do: _), contents) do
       contents =
        case contents do
          [do: _] ->

--- a/lib/amrita/checkers.ex
+++ b/lib/amrita/checkers.ex
@@ -18,7 +18,7 @@ defmodule Amrita.Checkers do
         end
 
     """
-    defmacro defchecker(name, _ // quote(do: _), contents) do
+    defmacro defchecker(name, _ \\ quote(do: _), contents) do
       { fun_name, _, args } = name
 
       neg_args = Enum.drop(args, 1)

--- a/lib/amrita/engine/start.ex
+++ b/lib/amrita/engine/start.ex
@@ -1,7 +1,7 @@
 defmodule Amrita.Engine.Start do
   @moduledoc false
 
-  def now(options // []) do
+  def now(options \\ []) do
     :application.start(:elixir)
     :application.start(:ex_unit)
 

--- a/lib/amrita/mocks.ex
+++ b/lib/amrita/mocks.ex
@@ -8,7 +8,7 @@ defmodule Amrita.Mocks do
 
   """
 
-  defmacro __using__(_ // []) do
+  defmacro __using__(_ \\ []) do
     quote do
       import Amrita.Mocks.Provided
     end
@@ -77,14 +77,14 @@ defmodule Amrita.Mocks do
       end
     end
 
-    def __resolve_args__(prerequisites, target_module, env, local_bindings // []) do
+    def __resolve_args__(prerequisites, target_module, env, local_bindings \\ []) do
       Provided.Prerequisites.map prerequisites, fn { module, fun, args, _, value } ->
         new_args = Enum.map args, fn arg -> __resolve_arg__(arg, target_module, env, local_bindings) end
         { module, fun, new_args, args, value }
       end
     end
 
-    def __resolve_arg__(arg, target_module, env, local_bindings // []) do
+    def __resolve_arg__(arg, target_module, env, local_bindings \\ []) do
       case arg do
         { :_, _, _ }          -> anything
         { :fn, _meta, args }   -> { evaled_arg, _ } = Code.eval_quoted(arg, [], env)

--- a/lib/amrita/syntax/describe.ex
+++ b/lib/amrita/syntax/describe.ex
@@ -5,7 +5,7 @@ defmodule Amrita.Syntax.Describe do
   Provides an alternative DSL to facts and fact.
   """
   lc facts_alias inlist [:context, :describe] do
-    defmacro unquote(facts_alias)(description, thing // quote(do: _), contents) do
+    defmacro unquote(facts_alias)(description, thing \\ quote(do: _), contents) do
       quote do
         Amrita.Facts.facts(unquote(description), unquote(thing), unquote(contents))
       end
@@ -13,7 +13,7 @@ defmodule Amrita.Syntax.Describe do
   end
 
   lc fact_alias inlist [:it, :specify] do
-    defmacro unquote(fact_alias)(description, provided // [], meta // quote(do: _), contents) do
+    defmacro unquote(fact_alias)(description, provided \\ [], meta \\ quote(do: _), contents) do
       quote do
         Amrita.Facts.fact(unquote(description), unquote(provided), unquote(meta), unquote(contents))
       end
@@ -26,19 +26,19 @@ defmodule Amrita.Syntax.Describe do
     end
   end
 
-  defmacro before_each(var // quote(do: _), block) do
+  defmacro before_each(var \\ quote(do: _), block) do
     quote do: ExUnit.Callbacks.setup(unquote(var), unquote(block))
   end
 
-  defmacro before_all(var // quote(do: _), block) do
+  defmacro before_all(var \\ quote(do: _), block) do
     quote do: ExUnit.Callbacks.setup_all(unquote(var), unquote(block))
   end
 
-  defmacro after_each(var // quote(do: _), block) do
+  defmacro after_each(var \\ quote(do: _), block) do
     quote do: ExUnit.Callbacks.teardown(unquote(var), unquote(block))
   end
 
-  defmacro after_all(var // quote(do: _), block) do
+  defmacro after_all(var \\ quote(do: _), block) do
     quote do: ExUnit.Callbacks.teardown_all(unquote(var), unquote(block))
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -13,7 +13,7 @@ defmodule Support do
     end
   end
 
-  defmacro failing_fact(name, _ // quote(do: _), contents) do
+  defmacro failing_fact(name, _ \\ quote(do: _), contents) do
     quote do
       fact unquote(name) do
         fail unquote(name) do
@@ -23,7 +23,7 @@ defmodule Support do
     end
   end
 
-  defmacro fail(_name // "", _ // quote(do: _), contents) do
+  defmacro fail(_name \\ "", _ \\ quote(do: _), contents) do
     Support.Wrap.assertions(contents)
   end
 


### PR DESCRIPTION
Elixir now uses \\ instead of // for default arguments.
