### PR TITLE
re #104 changing mix.exs because :env key in mix.exs project configuration is deprecated

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -15,9 +15,7 @@ defmodule Amrita.Mixfile do
                        {"Source", "http://github.com/josephwilk/amrita"}],
               contributors: ["Joseph Wilk"],
               licenses: ["MIT"]],
-     env: [test: [deps: deps],
-           dev:  [deps: deps ++ dev_deps]],
-     deps: deps]
+     deps: deps(Mix.env)]
   end
 
   def version do
@@ -28,7 +26,19 @@ defmodule Amrita.Mixfile do
     []
   end
 
-  defp deps do
+  defp deps(:dev) do
+    base_deps
+  end
+
+  defp deps(:test) do
+    base_deps ++ dev_deps
+  end
+  
+  defp deps(_) do
+    base_deps
+  end
+
+  defp base_deps do
     [{:meck, [branch: "master" ,github: "eproxus/meck"]}]
   end
 


### PR DESCRIPTION
Changing mix.exs because `:env` key in `mix.exs` project configuration is deprecatedon is deprecated (Will be removed in next version)
