### PR TITLE
Starting updating deprecated Hashdict.new by cleaning up tests

### DIFF
--- a/test/integration/t_mocks.exs
+++ b/test/integration/t_mocks.exs
@@ -128,13 +128,13 @@ defmodule Integration.MockFacts do
       end
 
       fact "dict" do
-        provided [Integration.MockFacts.Funk.hip?(HashDict.new([{:a,1}])) |> false] do
-          Funk.hip?(HashDict.new([{:a, 1}])) |> falsey
+        provided [Integration.MockFacts.Funk.hip?(Enum.into([{:a, 1}], [])) |> false] do
+          Funk.hip?(Enum.into([{:a, 1}], [])) |> falsey
         end
 
         fail do
-          provided [Integration.MockFacts.Funk.hip?(HashDict.new([{:a, 1}])) |> false] do
-            Funk.hip?(HashDict.new([{:a, 2}])) |> falsey
+          provided [Integration.MockFacts.Funk.hip?(Enum.into([{:a, 1}], [])) |> false] do
+            Funk.hip?(Enum.into([{:a, 2}], [])) |> falsey
           end
         end
       end

--- a/test/unit/amrita/elixir/t_pipeline.exs
+++ b/test/unit/amrita/elixir/t_pipeline.exs
@@ -101,10 +101,10 @@ defmodule PipelineFacts do
     end
 
     fact "hashdict" do
-      HashDict.new([{:b, 1}, {:a, 2}]) |> HashDict.new([{:b, 1}, {:a, 2}])
+      Enum.into([{:b, 1}], [{:a, 2}]) |> equals Enum.into([{:b, 1}], [{:a, 2}])
 
       fail do
-        HashDict.new([{:b, 1}, {:a, 2}]) |> HashDict.new([{:b, 1}, {:a, 6}])
+        Enum.into([{:b, 1}], [{:a, 2}]) |> equals Enum.into([{:b, 1}], [{:a, 6}])
       end
     end
 


### PR DESCRIPTION
Could you look at this if I got it correct. All the tests passes
