### PR TITLE
Use __struct__ in place of __record__(:name)

### DIFF
--- a/lib/amrita/checkers/exceptions.ex
+++ b/lib/amrita/checkers/exceptions.ex
@@ -47,7 +47,7 @@ defmodule Amrita.Checkers.Exceptions do
         Message.fail message, expected, __ENV__.function
       end
     else
-      Message.fail error.__record__(:name), expected, __ENV__.function
+      Message.fail error.__struct__, expected, __ENV__.function
     end
   end
 


### PR DESCRIPTION
Fixes the below failure

```
1) test ! negates the predicate - raises (Integration.AmritaFacts)
     test/integration/t_amrita.exs:317
     ** (ArgumentError) argument error
     stacktrace:
       (amrita) lib/amrita/checkers/simple.ex:223: Amrita.Checkers.Simple.!/2
       test/integration/t_amrita.exs:318
```
